### PR TITLE
Fix data exports and reply duplication

### DIFF
--- a/src/screens/PostDetailScreen/index.tsx
+++ b/src/screens/PostDetailScreen/index.tsx
@@ -87,14 +87,6 @@ export default function PostDetailScreen() {
     if (!replyText.trim()) return;
 
     setSubmitting(true);
-    await addDoc(
-      collection(db, 'posts', postId, 'replies'),  
-      {
-        text:      replyText,            
-        authorId:  auth.currentUser!.uid,  
-        createdAt: serverTimestamp(),  
-      }
-);
     try {
       await addDoc(collection(db, 'posts', postId, 'replies'), {
         text: replyText,

--- a/src/utils/MockData.ts
+++ b/src/utils/MockData.ts
@@ -1,31 +1,33 @@
 import { NewsItem, ForumPost } from '../types';
 
-// export const newsData: NewsItem[] = [
-//   {
-//     id: 1,
-//     title: 'Nova expansão de Magic: The Gathering é revelada!',
-//     category: 'Magic',
-//     content: `A Wizards of the Coast revelou oficialmente sua mais nova expansão de Magic: The Gathering, intitulada "Horizontes Mecânicos". Esta coleção promete levar os jogadores a um futuro distópico, onde artefatos ganham vida e planoswalkers enfrentam dilemas tecnológicos profundos.
-//     Com mais de 250 cartas inéditas, a nova edição introduz mecânicas revolucionárias como "Circuitar", que permite sinergias entre magias e permanentes de artefato, além de uma série de criaturas híbridas que mesclam biologia mágica com engenharia avançada. 
-//     A Wizards também confirmou o retorno de personagens icônicos como Tezzeret e Saheeli, em versões totalmente reformuladas.`,
-//   },
-//   {
-//     id: 2,
-//     title: 'Yu-Gi-Oh! lança booster inédito no Brasil',
-//     category: 'Yu-Gi-Oh!',
-//      content: `A Konami anunciou o lançamento exclusivo do booster "Força das Sombras" no Brasil, com cartas inéditas voltadas para os duelistas da América Latina. A coleção conta com 60 novas cartas, incluindo reprints de staples como Ash Blossom & Joyous Spring, além de arquétipos populares como Despia e Spright.
-//     Dentre os destaques está o monstro "Dragão Sombrio Cósmico", uma carta de Nível 8 com efeitos disruptivos que pode anular efeitos do oponente durante o turno dele. Também foram introduzidas novas Magias Rituais e Armadilhas com suporte para decks de Invocação-Fusão.
-//     O booster será essencial para torneios locais e regionais, promovendo uma grande reformulação no metagame competitivo. Duelistas brasileiros poderão adquirir a coleção nas lojas a partir da próxima semana.`
-//   },
-//   {
-//     id: 3,
-//     title: 'Pokémon TCG celebra 30 anos com evento global',
-//     category: 'Pokémon',
-//     content: `O Pokémon Trading Card Game está comemorando seu 30º aniversário em grande estilo com o lançamento da coleção especial "Festival Brilhante". A expansão traz cartas holográficas comemorativas de Pikachu, Charizard, Mewtwo e outros favoritos da franquia, além de itens colecionáveis exclusivos como sleeves, playmats e boosters dourados.
-//     O evento global de celebração contará com transmissões ao vivo, torneios online com prêmios oficiais e distribuição de cartas promocionais para participantes. Jogadores de todo o mundo poderão batalhar e interagir com treinadores lendários em uma experiência inédita.
-//     A coleção "Festival Brilhante" também introduz a mecânica "Reação Elemental", que permite efeitos combinados entre cartas de tipos diferentes, incentivando decks híbridos e estratégias criativas. A expansão será disponibilizada em pacotes especiais a partir do próximo mês.`
-//   },
-// ];
+// Dados de notícias exibidos na tela de "News". Em versões anteriores o
+// conteúdo estava comentado e o import resultava em "undefined". Para que o
+// app funcione sem depender de uma fonte externa, disponibilizamos alguns
+// registros básicos.
+
+export const newsData: NewsItem[] = [
+  {
+    id: '1',
+    title: 'Nova expansão de Magic: The Gathering é revelada!',
+    category: 'Magic',
+    content:
+      'A Wizards of the Coast anunciou a coleção "Horizontes Mecânicos", trazendo mais de 250 cartas e novas mecânicas baseadas em artefatos.',
+  },
+  {
+    id: '2',
+    title: 'Yu-Gi-Oh! lança booster inédito no Brasil',
+    category: 'Yu-Gi-Oh!',
+    content:
+      'O booster "Força das Sombras" chega com 60 cartas inéditas e reprints importantes para o cenário competitivo latino-americano.',
+  },
+  {
+    id: '3',
+    title: 'Pokémon TCG celebra 30 anos com evento global',
+    category: 'Pokémon',
+    content:
+      'A série comemorativa "Festival Brilhante" marca três décadas do jogo com cartas promocionais e torneios especiais ao redor do mundo.',
+  },
+];
 
 
 export const forumPosts: ForumPost[] = [


### PR DESCRIPTION
## Summary
- provide `newsData` sample array so news screens work
- avoid adding duplicate replies in `PostDetailScreen`

## Testing
- `npx tsc` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6846ec79507483248712f0634ed28285